### PR TITLE
C++98 fixes, part 2

### DIFF
--- a/samples/ExternalFunction/ExternalFunction.cpp
+++ b/samples/ExternalFunction/ExternalFunction.cpp
@@ -84,7 +84,6 @@ public:
         assert(args[0].null() == false);    
 
         using std::sqrt;
-#endif
 
         return executionContext.getXObjectFactory().createNumber(sqrt(args[0]->num(executionContext)));
     }

--- a/src/xalanc/ICUBridge/ICUXalanNumberFormatProxy.cpp
+++ b/src/xalanc/ICUBridge/ICUXalanNumberFormatProxy.cpp
@@ -72,7 +72,7 @@ ICUXalanNumberFormatProxy::format(double    theValue,
 
 
 XalanDOMString&
-ICUXalanNumberFormatProxy::format(int               theValue,
+ICUXalanNumberFormatProxy::format(XMLInt16          theValue,
                                   XalanDOMString&   theResult)
 {
     UnicodeString   theUnicodeResult;
@@ -86,7 +86,7 @@ ICUXalanNumberFormatProxy::format(int               theValue,
 
 
 XalanDOMString&
-ICUXalanNumberFormatProxy::format(unsigned int  theValue, XalanDOMString& theResult)
+ICUXalanNumberFormatProxy::format(XMLUInt16 theValue, XalanDOMString& theResult)
 {
     UnicodeString   theUnicodeResult;
 
@@ -97,7 +97,7 @@ ICUXalanNumberFormatProxy::format(unsigned int  theValue, XalanDOMString& theRes
 
 
 XalanDOMString&
-ICUXalanNumberFormatProxy::format(long            theValue,
+ICUXalanNumberFormatProxy::format(XMLInt32        theValue,
                                   XalanDOMString& theResult)
 {
     UnicodeString   theUnicodeResult;
@@ -112,7 +112,7 @@ ICUXalanNumberFormatProxy::format(long            theValue,
 
 
 XalanDOMString&
-ICUXalanNumberFormatProxy::format(unsigned long   theValue,
+ICUXalanNumberFormatProxy::format(XMLUInt32       theValue,
                                   XalanDOMString& theResult)
 {
     UnicodeString   theUnicodeResult;

--- a/src/xalanc/ICUBridge/ICUXalanNumberFormatProxy.hpp
+++ b/src/xalanc/ICUBridge/ICUXalanNumberFormatProxy.hpp
@@ -57,25 +57,25 @@ public:
 
     virtual XalanDOMString&
     format(
-            int                 theValue,
+            XMLInt16            theValue,
             XalanDOMString&     theResult);
 
 
     virtual XalanDOMString&
     format(
-            unsigned int        theValue,
+            XMLUInt16           theValue,
             XalanDOMString&     theResult);
 
 
     virtual XalanDOMString&
     format(
-            long                theValue,
+            XMLInt32            theValue,
             XalanDOMString&     theResult);
 
 
     virtual XalanDOMString&
     format(
-            unsigned long       theValue,
+            XMLUInt32           theValue,
             XalanDOMString&     theResult);
 
     /**


### PR DESCRIPTION
Additional fixes to follow #3 for code which isn't compiled by default with the Autoconf build.