### PR TITLE
Remove support for Xerces-C++ version 2

### DIFF
--- a/src/xalanc/Include/PlatformDefinitions.hpp
+++ b/src/xalanc/Include/PlatformDefinitions.hpp
@@ -68,15 +68,9 @@ namespace xalanc = XALAN_CPP_NAMESPACE;
 
 namespace XALAN_CPP_NAMESPACE {
 
-#if XERCES_VERSION_MAJOR < 3
-typedef unsigned int    XalanSize_t;
-typedef unsigned int    XalanFilePos;
-typedef XMLSSize_t      XalanFileLoc;
-#else
 typedef XMLSize_t       XalanSize_t;
 typedef XMLFilePos      XalanFilePos;
 typedef XMLFileLoc      XalanFileLoc;
-#endif
 
 typedef XMLCh           XalanDOMChar;
 typedef unsigned int    XalanUnicodeChar;


### PR DESCRIPTION
Xerces-C++ v2 is long unsupported.  Drop support from Xalan.