### PR TITLE
Add Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,40 @@
+language: c
+
+sudo: false
+dist: trusty
+
+cache:
+  directories:
+    - download
+
+addons:
+  apt_packages:
+    - libxerces-c-dev
+    - libicu-dev
+    - libcurl4-openssl-dev
+    - autoconf
+    - automake
+    - libtool
+
+before_install:
+  - if test "$(uname -s)" = Darwin; then brew update; fi
+  - if test "$(uname -s)" = Darwin; then brew install xerces-c; fi
+
+os:
+  - linux
+  - osx
+
+env:
+  matrix:
+    - BUILD=autoconf TYPE=Release MSGLOADER=inmem TRANSCODER=default
+    - BUILD=cmake TOOL="Unix Makefiles" TYPE=Debug MSGLOADER=inmemory TRANSCODER=default
+    - BUILD=cmake TOOL="Ninja" TYPE=Release MSGLOADER=inmemory TRANSCODER=icu
+
+matrix:
+  fast_finish: true
+  exclude:
+    - os: osx
+      env: BUILD=cmake TOOL="Ninja" TYPE=Release MSGLOADER=inmemory TRANSCODER=icu
+
+script:
+  - ./scripts/ci-travis "$BUILD" "$TOOL" "$TYPE" "$MSGLOADER" "$TRANSCODER"

--- a/scripts/ci-travis
+++ b/scripts/ci-travis
@@ -1,0 +1,133 @@
+#!/bin/sh
+# This script is used for testing the build, primarily for use
+# with travis, but may be used by hand as well.
+
+set -e
+set -x
+
+# Test autoconf build
+autoconf_build()
+{
+    opts=""
+    if [ -n "$3" ]; then
+        opts="$opts -m $3"
+    fi
+    if [ -n "$4" ]; then
+        opts="$opts -t $4"
+    fi
+    case $(uname -s) in
+        Linux) opts="$opts -p linux";;
+        Darwin) opts="$opts -p macosx";;
+    esac
+
+    autoreconf -ivf
+
+    export XALANCROOT=$(pwd)
+    export CXXFLAGS=-std=c++11
+
+    mkdir autoconf-build
+    cd autoconf-build
+    echo "Running ../runConfigure -P $(pwd)/../autoconf-install) ${opts}"
+    ../runConfigure -P $(pwd)/../autoconf-install ${opts}
+    make
+    make samples
+    make install
+    make install-package
+    make tests
+}
+
+# Install needed tools
+cmake_deps()
+{
+    mkdir -p download
+    mkdir -p tools
+
+    if [ "$(uname -s)" = "Linux" ]; then
+        cmake_file="cmake-3.8.2-Linux-x86_64.tar.gz"
+        cmake_hash="574673d3f37b0be6a0813b894a8bce9c4af08c13f1ec25c030a69f42e0e4b349e0192385ef20c8a9271055b7c3b24c5b20fb5009762131a3fba3d17576e641f1"
+    elif [ "$(uname -s)" = "Darwin" ]; then
+        cmake_file="cmake-3.8.2-Darwin-x86_64.tar.gz"
+        cmake_hash="fd1c09dd73fe2b23fdc9ac915a90343d2e27409182dd1f2bf509ddf54ca926f97e1906fc18f119e8ea52797c05d4b919772f43500bffbcf2c3cdc86828d9067e"
+    fi
+    cmake_url="https://cmake.org/files/v3.8/${cmake_file}"
+
+    if [ "$(uname -s)" = "Linux" ]; then
+        ninja_file="ninja-linux.zip"
+        ninja_hash="2dddc52750c5e6f841acd0d978b894c9a6562f12ddb4ba9e5118a213f54265f065682ffe1bc7bc2ac6146760145d17800a4b7373791cd1fbbaf0836faf050e19"
+    elif [ "$(uname -s)" = "Darwin" ]; then
+        ninja_file="ninja-mac.zip"
+        ninja_hash="e008c9814447bbf356be7f2daf6d212657fb22b67e7de3885bd2f27766cd7c8a2ad61a4aace170674464ccf55813cbe2bf311485bc2058e89867f17b692642b9"
+    fi
+    ninja_url="https://github.com/ninja-build/ninja/releases/download/v1.7.2/${ninja_file}"
+
+    (
+        cd download
+        if [ ! -f "$cmake_file" ] || [ "$(shasum -a 512 "$cmake_file")" != "$cmake_hash  $cmake_file" ]; then
+            wget "$cmake_url"
+            if [ "$(shasum -a 512 "$cmake_file")" != "$cmake_hash  $cmake_file" ]; then
+                echo "Error: cmake download hash mismatch" >&2
+                exit 1
+            fi
+        fi
+        tar xf "$cmake_file"
+        cp -a ${cmake_file%.tar.gz}/* ../tools
+
+        if [ "$1" = "Ninja" ]; then
+            if [ ! -f "$ninja_file" ] || [ "$(shasum -a 512 "$ninja_file")" != "$ninja_hash  $ninja_file" ]; then
+                wget "$ninja_url"
+                if [ "$(shasum -a 512 "$ninja_file")" != "$ninja_hash  $ninja_file" ]; then
+                    echo "Error: ninja download hash mismatch" >&2
+                    exit 1
+                fi
+            fi
+            unzip "$ninja_file"
+            mkdir -p ../tools/bin
+            mv ninja ../tools/bin
+        fi
+    )
+}
+
+# Test autoconf build
+cmake_build()
+{
+    opts=""
+    if [ -n "$3" ]; then
+        opts="$opts -Dmessage-loader=$3"
+    fi
+    if [ -n "$4" ]; then
+        opts="$opts -Dtranscoder=$4"
+    fi
+
+    PATH="$(pwd)/tools/bin:$PATH"
+    if [ "$(uname -s)" = "Darwin" ]; then
+        PATH="$(pwd)/tools/CMake.app/Contents/bin:$PATH"
+    fi
+    mkdir cmake-build
+    cd cmake-build
+    echo "Running cmake -G "$1" -DCMAKE_BUILD_TYPE="$2" -DCMAKE_INSTALL_PREFIX=../cmake-install ${opts} .."
+    cmake -G "$1" -DCMAKE_BUILD_TYPE="$2" -DCMAKE_INSTALL_PREFIX=../cmake-install ${opts} ..
+    cmake --build .
+    cmake --build . --target install
+    ctest -V
+}
+
+build=$1
+shift
+
+case $build in
+    autoconf)
+        echo "Testing Autoconf build"
+        autoconf_build "$@"
+        ;;
+    cmake)
+        echo "Testing CMake build"
+        cmake_deps "$@"
+        cmake_build "$@"
+        ;;
+    *)
+        echo "Invalid argument: \"$arg\"" >&2
+        exit 1
+        ;;
+esac
+
+exit 0


### PR DESCRIPTION
This PR adds support for testing commits with TravisCI on Linux and MacOS.  Both the original Autoconf-based build and the new CMake-based build are tested.

Testing: Check all builds pass.