### PR TITLE
Use -1 as npos value

### DIFF
--- a/src/xalanc/PlatformSupport/Writer.cpp
+++ b/src/xalanc/PlatformSupport/Writer.cpp
@@ -24,7 +24,7 @@ namespace XALAN_CPP_NAMESPACE {
 
 
 
-const size_t    Writer::npos = ~0u;
+const size_t    Writer::npos = static_cast<size_t>(-1);
 
 
 

--- a/src/xalanc/XPath/NodeRefListBase.cpp
+++ b/src/xalanc/XPath/NodeRefListBase.cpp
@@ -24,7 +24,7 @@ namespace XALAN_CPP_NAMESPACE {
 
 
 
-const NodeRefListBase::size_type    NodeRefListBase::npos = ~0u;
+const NodeRefListBase::size_type    NodeRefListBase::npos = static_cast<NodeRefListBase::size_type>(-1);
 
 
 

--- a/src/xalanc/XalanDOM/XalanDOMString.cpp
+++ b/src/xalanc/XalanDOM/XalanDOMString.cpp
@@ -32,7 +32,7 @@ namespace XALAN_CPP_NAMESPACE {
 
 const XalanDOMChar  XalanDOMString::s_empty = 0;
 
-const XalanDOMString::size_type  XalanDOMString::npos = ~0u;
+const XalanDOMString::size_type  XalanDOMString::npos = static_cast<XalanDOMString::size_type>(-1);
 
 
 XalanDOMString::XalanDOMString(MemoryManager&  theManager) :


### PR DESCRIPTION
This is to match usage in the standard library.  For unsigned types, there will be no change in the effective value.