### PR TITLE
XALANC-795: Run samples with ctest

### DIFF
--- a/docs/samples.md
+++ b/docs/samples.md
@@ -257,8 +257,8 @@ SimpleXPathCAPI XMLFile XPathExpression
 
 where *XMLFile* is an XML source file, and *XPathExpression* is an
 XPath expression to apply to the XML source file. The
-*SimpleXPathCAPI* subdirectory contains an XML file named *xml.foo*
-identical to *foo.xml* in the preceding example.
+*SimpleXPathCAPI* subdirectory contains an XML file named *foo.xml*
+similar to the *foo.xml* in the preceding example.
 
 You can try command lines like:
 

--- a/docs/samples.md
+++ b/docs/samples.md
@@ -160,7 +160,7 @@ XPath expression to an XML document.
 Run this sample from the *SerializeNodeSet* subdirectory with
 
 ```sh
-SerializeNodeSet XMLFile ContextNode XPathExpression`
+SerializeNodeSet XMLFile ContextNode XPathExpression
 ```
 
 where *XMLFile* is an XML source file, *ContextNode* is the location

--- a/docs/samples.md
+++ b/docs/samples.md
@@ -222,13 +222,13 @@ The *XPathWrapper* subdirectory contains an XML file named *xml.foo*
 You can try command lines like
 
 ```sh
-SimpleXPathAPI foo.xml /doc name/@last
+SimpleXPathAPI foo.xml /foo:doc foo:name/@last
 ```
 
 and
 
 ```sh
-SimpleXPathAPI foo.xml / '//name[position()="4"]/@first'
+SimpleXPathAPI foo.xml / '//foo:name[position()="4"]/@first'
 ```
 
 Note: If a `SimpleXPathAPI` argument includes characters (such as `*`)

--- a/docs/samples.md
+++ b/docs/samples.md
@@ -126,7 +126,7 @@ write the ouput to *foo.out*.
 You can run it from the *DocumentBuilder* subdirectory with
 `DocumentBuilder`.
 
-## ExternalFunctions
+## ExternalFunction
 
 What it does: implement, install, and illustrate the usage of three
 extension functions.  The functions return a square root, a cube, and a
@@ -136,8 +136,8 @@ XML document (*foo.xml*), computes the length of each side of a cube
 and the volume of the cube, and enters the date and time of the
 transformation. The output appears in *foo.out*.
 
-Run this sample from the *ExternalFunctions* subdirectory with
-`ExternalFunctions`.
+Run this sample from the *ExternalFunction* subdirectory with
+`ExternalFunction`.
 
 See also: [Extension Functions](faq.md#extension-functions).
 

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -50,3 +50,18 @@ foreach(sample
   set_target_properties(${sample} PROPERTIES FOLDER "Samples")
   add_dependencies(samples ${sample})
 endforeach()
+
+add_test(NAME CompileStylesheet
+        COMMAND $<TARGET_FILE:CompileStylesheet>
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/CompileStylesheet")
+
+foreach(sample
+        CompileStylesheet)
+  if(msgloader STREQUAL "nls")
+    set_tests_properties(${sample} PROPERTIES ENVIRONMENT "NLSPATH=${PROJECT_BINARY_DIR}/src/xalanc/NLS/gen/Xalan.cat")
+  endif()
+  if(WIN32)
+    string(REPLACE ";" "\\;" OLDPATH "$ENV{PATH}")
+    set_tests_properties(${sample} PROPERTIES ENVIRONMENT "PATH=$<SHELL_PATH:$<TARGET_FILE_DIR:xalan-c>>\;$<SHELL_PATH:$<TARGET_FILE_DIR:xalanMsg>>\;${OLDPATH}")
+  endif()
+endforeach()

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -114,6 +114,10 @@ add_test(NAME XalanTransformerCallback
         COMMAND $<TARGET_FILE:XalanTransformerCallback> "foo.xml" "foo.xsl"
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/XalanTransformerCallback")
 
+add_test(NAME SimpleXPathCAPI
+        COMMAND $<TARGET_FILE:SimpleXPathCAPI> "foo.xml" "/doc/name[3]"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/SimpleXPathCAPI")
+
 foreach(sample
         CompileStylesheet
         DocumentBuilder
@@ -133,7 +137,8 @@ foreach(sample
         TransformToXercesDOM
         UseStylesheetParam
         XalanTransform
-        XalanTransformerCallback)
+        XalanTransformerCallback
+        SimpleXPathCAPI)
   if(msgloader STREQUAL "nls")
     set_tests_properties(${sample} PROPERTIES ENVIRONMENT "NLSPATH=${PROJECT_BINARY_DIR}/src/xalanc/NLS/gen/Xalan.cat")
   endif()

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -67,6 +67,14 @@ add_test(NAME SerializeNodeSet
          COMMAND $<TARGET_FILE:SerializeNodeSet> "foo.xml" "/doc" "name[@first='David']"
          WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/SerializeNodeSet")
 
+add_test(NAME SimpleXPathAPI-1
+        COMMAND $<TARGET_FILE:SimpleXPathAPI> "foo.xml" "/foo:doc" "foo:name/@last"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/SimpleXPathAPI")
+
+add_test(NAME SimpleXPathAPI-2
+        COMMAND $<TARGET_FILE:SimpleXPathAPI> "foo.xml" "/" "//foo:name[position()=\"4\"]/@first"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/SimpleXPathAPI")
+
 foreach(sample
         CompileStylesheet
         DocumentBuilder
@@ -74,7 +82,9 @@ foreach(sample
         ExternalFunction
         ParsedSourceWrappers
         SimpleTransform
-        SerializeNodeSet)
+        SerializeNodeSet
+        SimpleXPathAPI-1
+        SimpleXPathAPI-2)
   if(msgloader STREQUAL "nls")
     set_tests_properties(${sample} PROPERTIES ENVIRONMENT "NLSPATH=${PROJECT_BINARY_DIR}/src/xalanc/NLS/gen/Xalan.cat")
   endif()

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -55,7 +55,8 @@ foreach(sample
         CompileStylesheet
         DocumentBuilder
         EntityResolver
-        ExternalFunction)
+        ExternalFunction
+        ParsedSourceWrappers)
   add_test(NAME ${sample}
           COMMAND $<TARGET_FILE:${sample}>
           WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${sample}")
@@ -65,7 +66,8 @@ foreach(sample
         CompileStylesheet
         DocumentBuilder
         EntityResolver
-        ExternalFunction)
+        ExternalFunction
+        ParsedSourceWrappers)
   if(msgloader STREQUAL "nls")
     set_tests_properties(${sample} PROPERTIES ENVIRONMENT "NLSPATH=${PROJECT_BINARY_DIR}/src/xalanc/NLS/gen/Xalan.cat")
   endif()

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -58,16 +58,21 @@ foreach(sample
         ExternalFunction
         ParsedSourceWrappers)
   add_test(NAME ${sample}
-          COMMAND $<TARGET_FILE:${sample}>
-          WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${sample}")
+           COMMAND $<TARGET_FILE:${sample}>
+           WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${sample}")
 endforeach()
+
+add_test(NAME SerializeNodeSet
+         COMMAND $<TARGET_FILE:SerializeNodeSet> "foo.xml" "/doc" "name[@first='David']"
+         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/SerializeNodeSet")
 
 foreach(sample
         CompileStylesheet
         DocumentBuilder
         EntityResolver
         ExternalFunction
-        ParsedSourceWrappers)
+        ParsedSourceWrappers
+        SerializeNodeSet)
   if(msgloader STREQUAL "nls")
     set_tests_properties(${sample} PROPERTIES ENVIRONMENT "NLSPATH=${PROJECT_BINARY_DIR}/src/xalanc/NLS/gen/Xalan.cat")
   endif()

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -105,6 +105,10 @@ add_test(NAME UseStylesheetParam
           "-d" "parmB" "parmB.xml"
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/UseStylesheetParam")
 
+add_test(NAME XalanTransform
+        COMMAND $<TARGET_FILE:XalanTransform> "foo.xml" "foo.xsl"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/XalanTransform")
+
 foreach(sample
         CompileStylesheet
         DocumentBuilder
@@ -121,7 +125,8 @@ foreach(sample
         TraceListen-3
         TraceListen-4
         TransformToXercesDOM
-        UseStylesheetParam)
+        UseStylesheetParam
+        XalanTransform)
   if(msgloader STREQUAL "nls")
     set_tests_properties(${sample} PROPERTIES ENVIRONMENT "NLSPATH=${PROJECT_BINARY_DIR}/src/xalanc/NLS/gen/Xalan.cat")
   endif()

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -55,8 +55,13 @@ add_test(NAME CompileStylesheet
         COMMAND $<TARGET_FILE:CompileStylesheet>
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/CompileStylesheet")
 
+add_test(NAME DocumentBuilder
+        COMMAND $<TARGET_FILE:DocumentBuilder>
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/DocumentBuilder")
+
 foreach(sample
-        CompileStylesheet)
+        CompileStylesheet
+        DocumentBuilder)
   if(msgloader STREQUAL "nls")
     set_tests_properties(${sample} PROPERTIES ENVIRONMENT "NLSPATH=${PROJECT_BINARY_DIR}/src/xalanc/NLS/gen/Xalan.cat")
   endif()

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -54,7 +54,8 @@ endforeach()
 foreach(sample
         CompileStylesheet
         DocumentBuilder
-        EntityResolver)
+        EntityResolver
+        ExternalFunction)
   add_test(NAME ${sample}
           COMMAND $<TARGET_FILE:${sample}>
           WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${sample}")
@@ -63,7 +64,8 @@ endforeach()
 foreach(sample
         CompileStylesheet
         DocumentBuilder
-        EntityResolver)
+        EntityResolver
+        ExternalFunction)
   if(msgloader STREQUAL "nls")
     set_tests_properties(${sample} PROPERTIES ENVIRONMENT "NLSPATH=${PROJECT_BINARY_DIR}/src/xalanc/NLS/gen/Xalan.cat")
   endif()

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -76,6 +76,22 @@ add_test(NAME SimpleXPathAPI-2
         COMMAND $<TARGET_FILE:SimpleXPathAPI> "foo.xml" "/" "//foo:name[position()=\"4\"]/@first"
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/SimpleXPathAPI")
 
+add_test(NAME TraceListen-1
+        COMMAND $<TARGET_FILE:TraceListen> "-tt"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/TraceListen")
+
+add_test(NAME TraceListen-2
+        COMMAND $<TARGET_FILE:TraceListen> "-tg"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/TraceListen")
+
+add_test(NAME TraceListen-3
+        COMMAND $<TARGET_FILE:TraceListen> "-ts"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/TraceListen")
+
+add_test(NAME TraceListen-4
+        COMMAND $<TARGET_FILE:TraceListen> "-ttc"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/TraceListen")
+
 foreach(sample
         CompileStylesheet
         DocumentBuilder
@@ -86,7 +102,11 @@ foreach(sample
         StreamTransform
         SerializeNodeSet
         SimpleXPathAPI-1
-        SimpleXPathAPI-2)
+        SimpleXPathAPI-2
+        TraceListen-1
+        TraceListen-2
+        TraceListen-3
+        TraceListen-4)
   if(msgloader STREQUAL "nls")
     set_tests_properties(${sample} PROPERTIES ENVIRONMENT "NLSPATH=${PROJECT_BINARY_DIR}/src/xalanc/NLS/gen/Xalan.cat")
   endif()

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -51,17 +51,19 @@ foreach(sample
   add_dependencies(samples ${sample})
 endforeach()
 
-add_test(NAME CompileStylesheet
-        COMMAND $<TARGET_FILE:CompileStylesheet>
-        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/CompileStylesheet")
-
-add_test(NAME DocumentBuilder
-        COMMAND $<TARGET_FILE:DocumentBuilder>
-        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/DocumentBuilder")
+foreach(sample
+        CompileStylesheet
+        DocumentBuilder
+        EntityResolver)
+  add_test(NAME ${sample}
+          COMMAND $<TARGET_FILE:${sample}>
+          WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${sample}")
+endforeach()
 
 foreach(sample
         CompileStylesheet
-        DocumentBuilder)
+        DocumentBuilder
+        EntityResolver)
   if(msgloader STREQUAL "nls")
     set_tests_properties(${sample} PROPERTIES ENVIRONMENT "NLSPATH=${PROJECT_BINARY_DIR}/src/xalanc/NLS/gen/Xalan.cat")
   endif()

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -56,7 +56,8 @@ foreach(sample
         DocumentBuilder
         EntityResolver
         ExternalFunction
-        ParsedSourceWrappers)
+        ParsedSourceWrappers
+        SimpleTransform)
   add_test(NAME ${sample}
            COMMAND $<TARGET_FILE:${sample}>
            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${sample}")
@@ -72,6 +73,7 @@ foreach(sample
         EntityResolver
         ExternalFunction
         ParsedSourceWrappers
+        SimpleTransform
         SerializeNodeSet)
   if(msgloader STREQUAL "nls")
     set_tests_properties(${sample} PROPERTIES ENVIRONMENT "NLSPATH=${PROJECT_BINARY_DIR}/src/xalanc/NLS/gen/Xalan.cat")

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -58,7 +58,8 @@ foreach(sample
         ExternalFunction
         ParsedSourceWrappers
         SimpleTransform
-        StreamTransform)
+        StreamTransform
+        ThreadSafe)
   add_test(NAME ${sample}
            COMMAND $<TARGET_FILE:${sample}>
            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${sample}")
@@ -121,6 +122,7 @@ foreach(sample
         ParsedSourceWrappers
         SimpleTransform
         StreamTransform
+        ThreadSafe
         SerializeNodeSet
         SimpleXPathAPI-1
         SimpleXPathAPI-2

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -96,6 +96,15 @@ add_test(NAME TransformToXercesDOM
         COMMAND $<TARGET_FILE:TransformToXercesDOM> "birds.xml" "birds.xsl"
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/TransformToXercesDOM")
 
+add_test(NAME UseStylesheetParam
+        COMMAND $<TARGET_FILE:UseStylesheetParam>
+          "foo.xml" "foo.xslt" "foo.out"
+          "-s" "stringA" "'This is a test string value'"
+          "-n" "numberA"  "123.012345"
+          "-d" "parmA" "parmA.xml"
+          "-d" "parmB" "parmB.xml"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/UseStylesheetParam")
+
 foreach(sample
         CompileStylesheet
         DocumentBuilder
@@ -111,7 +120,8 @@ foreach(sample
         TraceListen-2
         TraceListen-3
         TraceListen-4
-        TransformToXercesDOM)
+        TransformToXercesDOM
+        UseStylesheetParam)
   if(msgloader STREQUAL "nls")
     set_tests_properties(${sample} PROPERTIES ENVIRONMENT "NLSPATH=${PROJECT_BINARY_DIR}/src/xalanc/NLS/gen/Xalan.cat")
   endif()

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -57,7 +57,8 @@ foreach(sample
         EntityResolver
         ExternalFunction
         ParsedSourceWrappers
-        SimpleTransform)
+        SimpleTransform
+        StreamTransform)
   add_test(NAME ${sample}
            COMMAND $<TARGET_FILE:${sample}>
            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${sample}")
@@ -82,6 +83,7 @@ foreach(sample
         ExternalFunction
         ParsedSourceWrappers
         SimpleTransform
+        StreamTransform
         SerializeNodeSet
         SimpleXPathAPI-1
         SimpleXPathAPI-2)

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -109,6 +109,10 @@ add_test(NAME XalanTransform
         COMMAND $<TARGET_FILE:XalanTransform> "foo.xml" "foo.xsl"
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/XalanTransform")
 
+add_test(NAME XalanTransformerCallback
+        COMMAND $<TARGET_FILE:XalanTransformerCallback> "foo.xml" "foo.xsl"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/XalanTransformerCallback")
+
 foreach(sample
         CompileStylesheet
         DocumentBuilder
@@ -126,7 +130,8 @@ foreach(sample
         TraceListen-4
         TransformToXercesDOM
         UseStylesheetParam
-        XalanTransform)
+        XalanTransform
+        XalanTransformerCallback)
   if(msgloader STREQUAL "nls")
     set_tests_properties(${sample} PROPERTIES ENVIRONMENT "NLSPATH=${PROJECT_BINARY_DIR}/src/xalanc/NLS/gen/Xalan.cat")
   endif()

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -92,6 +92,10 @@ add_test(NAME TraceListen-4
         COMMAND $<TARGET_FILE:TraceListen> "-ttc"
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/TraceListen")
 
+add_test(NAME TransformToXercesDOM
+        COMMAND $<TARGET_FILE:TransformToXercesDOM> "birds.xml" "birds.xsl"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/TransformToXercesDOM")
+
 foreach(sample
         CompileStylesheet
         DocumentBuilder
@@ -106,7 +110,8 @@ foreach(sample
         TraceListen-1
         TraceListen-2
         TraceListen-3
-        TraceListen-4)
+        TraceListen-4
+        TransformToXercesDOM)
   if(msgloader STREQUAL "nls")
     set_tests_properties(${sample} PROPERTIES ENVIRONMENT "NLSPATH=${PROJECT_BINARY_DIR}/src/xalanc/NLS/gen/Xalan.cat")
   endif()


### PR DESCRIPTION
Run all samples with CTest.  Where samples take arguments, use arguments in documentation where possible (some documentation fixes made where these were broken).

Future actions:
* generate output in build directory, not source directory
* validate output matches expected output similar to xerces integration tests