### PR TITLE
Drop Conf and Performance tests

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -44,7 +44,7 @@ add_executable(Conf
 target_link_libraries(Conf XalanC::XalanC)
 set_target_properties(Conf PROPERTIES FOLDER "Tests")
 
-foreach(test Performance Threads Conf)
+foreach(test Threads)
   add_test(
     NAME ${test}
     COMMAND $<TARGET_FILE:${test}>


### PR DESCRIPTION
These require running with external test data from xalan-test.  Running with no arguments is pointless.

Look at restoring more of the tests as a post-1.12 action.