### PR TITLE
XALANC-807: CMake does not unconditionally use CMAKE_DEBUG_POSTFIX

### DIFF
--- a/docs/doxygen/CMakeLists.txt
+++ b/docs/doxygen/CMakeLists.txt
@@ -47,11 +47,17 @@ if(BUILD_DOXYGEN)
                     DEPENDS ${DOXYGEN_LOG})
   add_dependencies(doc-check ${PROJECT_NAME}-doc-check)
 
+  set_target_properties(${PROJECT_NAME}-doc-check PROPERTIES FOLDER "Documentation")
+  set_target_properties(doc-check PROPERTIES FOLDER "Documentation")
+
   if(NOT TARGET doc-api)
     add_custom_target(doc-api)
   endif()
   add_custom_target(${PROJECT_NAME}-doc-api ALL DEPENDS ${DOXYGEN_LOG} ${PROJECT_NAME}-doc-check)
   add_dependencies(doc-api ${PROJECT_NAME}-doc-api)
+
+  set_target_properties(${PROJECT_NAME}-doc-api PROPERTIES FOLDER "Documentation")
+  set_target_properties(doc-api PROPERTIES FOLDER "Documentation")
 
   install(DIRECTORY "${DOXYGEN_OUTPUT_DIR}/"
           DESTINATION "${CMAKE_INSTALL_DOCDIR}/api"

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -39,10 +39,12 @@ of changes are bugfixes or portability improvements.
 * [XALANC-795](https://issues.apache.org/jira/browse/XALANC-795): CMake CTest should run all samples as well as unit tests
 * [XALANC-797](https://issues.apache.org/jira/browse/XALANC-797): Generate XalanVersion.hpp
 * [XALANC-798](https://issues.apache.org/jira/browse/XALANC-798): Remove use of version.incl
+* [XALANC-799](https://issues.apache.org/jira/browse/XALANC-799): Remove use of winres.h in XalanMsgLib.rc
 * [XALANC-800](https://issues.apache.org/jira/browse/XALANC-800): Add CMake feature tests to replace specific platform definitions
 * [XALANC-801](https://issues.apache.org/jira/browse/XALANC-801): Enable AppVeyor CI for Windows
 * [XALANC-805](https://issues.apache.org/jira/browse/XALANC-805): Apply outstanding critical fixes
 * [XALANC-806](https://issues.apache.org/jira/browse/XALANC-806): C++98 and C++11 support
+* [XALANC-807](https://issues.apache.org/jira/browse/XALANC-807): CMake build unconditionally adds debug postfix with MSVC
 
 ### Improvement
 

--- a/src/xalanc/CMakeLists.txt
+++ b/src/xalanc/CMakeLists.txt
@@ -1013,8 +1013,8 @@ if(MSVC)
   target_compile_definitions(xalan-c PRIVATE "XALAN_DLL_NAME=\"$<TARGET_FILE_NAME:xalan-c>\\0\"")
   # Different naming for Windows than for Unix builds for backward
   # compatibility with the existing project files.
-  set_target_properties(xalan-c PROPERTIES OUTPUT_NAME "Xalan-C_${XALAN_MS_LIB_MAJOR_VER}${CMAKE_DEBUG_POSTFIX}")
-  set_target_properties(xalan-c PROPERTIES RUNTIME_OUTPUT_NAME "Xalan-C_${XALAN_MS_LIB_MAJOR_VER}_${XALAN_MS_LIB_MINOR_VER}${CMAKE_DEBUG_POSTFIX}")
+  set_target_properties(xalan-c PROPERTIES OUTPUT_NAME "Xalan-C_${XALAN_MS_LIB_MAJOR_VER}")
+  set_target_properties(xalan-c PROPERTIES RUNTIME_OUTPUT_NAME "Xalan-C_${XALAN_MS_LIB_MAJOR_VER}_${XALAN_MS_LIB_MINOR_VER}")
   set_target_properties(xalan-c PROPERTIES DEBUG_POSTFIX "D")
 else()
   # Not used for the common cases, though this would be the default if

--- a/src/xalanc/Utils/XalanMsgLib/CMakeLists.txt
+++ b/src/xalanc/Utils/XalanMsgLib/CMakeLists.txt
@@ -50,8 +50,8 @@ if(msgloader STREQUAL "inmemory")
     target_compile_definitions(xalanMsg PRIVATE "XALAN_DLL_NAME=\"$<TARGET_FILE_NAME:xalanMsg>\\0\"")
     # Different naming for Windows than for Unix builds for backward
     # compatibility with the existing project files.
-    set_target_properties(xalanMsg PROPERTIES OUTPUT_NAME "XalanMsgLib_${XALAN_MS_LIB_MAJOR_VER}${CMAKE_DEBUG_POSTFIX}")
-    set_target_properties(xalanMsg PROPERTIES RUNTIME_OUTPUT_NAME "XalanMessages_${XALAN_MS_LIB_MAJOR_VER}_${XALAN_MS_LIB_MINOR_VER}${CMAKE_DEBUG_POSTFIX}")
+    set_target_properties(xalanMsg PROPERTIES OUTPUT_NAME "XalanMsgLib_${XALAN_MS_LIB_MAJOR_VER}")
+    set_target_properties(xalanMsg PROPERTIES RUNTIME_OUTPUT_NAME "XalanMessages_${XALAN_MS_LIB_MAJOR_VER}_${XALAN_MS_LIB_MINOR_VER}")
     set_target_properties(xalanMsg PROPERTIES DEBUG_POSTFIX "D")
   else()
     # Not used for the common cases, though this would be the default if


### PR DESCRIPTION
* Drop use of CMAKE_DEBUG_POSTFIX where not appropriate
* Add Doxygen documentation to Documentation folder
* Update release notes