### PR TITLE
XALANC-812: Remove checks for NDEBUG and _DEBUG usage

### DIFF
--- a/src/xalanc/Include/PlatformDefinitions.hpp.in
+++ b/src/xalanc/Include/PlatformDefinitions.hpp.in
@@ -37,12 +37,6 @@
 #define XALAN_AUTO_PTR_REQUIRES_DEFINITION
 #endif
 
-#if defined(_DEBUG) && defined(NDEBUG)
-#error NDEBUG must not be defined when _DEBUG is defined.
-#elif !defined(_DEBUG) && !defined(NDEBUG)
-#error NDEBUG must be defined when _DEBUG is not defined.
-#endif
-
 #endif // _MSC_VER
 
 #if defined(__hpux)


### PR DESCRIPTION
Does not appear to have any detrimental effect.  Historical reasons for the check are unknown.