### PR TITLE
Fix building in MinGW

### DIFF
--- a/src/xalanc/Harness/XalanFileUtility.cpp
+++ b/src/xalanc/Harness/XalanFileUtility.cpp
@@ -2115,7 +2115,7 @@ XalanFileUtility::analyzeResults(XalanTransformer& xalan, const XalanDOMString& 
 
     if (result == 0)
     {
-#if defined(_MSC_VER)
+#if defined(XALAN_WINDOWS)
         CharVectorType theBuffer(getMemoryManager());
         TranscodeToLocalCodePage(theHTMLFile, theBuffer, true);
 

--- a/src/xalanc/Include/PlatformDefinitions.hpp.in
+++ b/src/xalanc/Include/PlatformDefinitions.hpp.in
@@ -53,7 +53,7 @@
 //  These defines provide the platform specific keywords that they need
 //  to do this.
 // ---------------------------------------------------------------------------
-#if defined(_MSC_VER)
+#if defined(XALAN_WINDOWS)
 #define XALAN_PLATFORM_EXPORT     __declspec(dllexport)
 #define XALAN_PLATFORM_IMPORT     __declspec(dllimport)
 #define XALAN_PLATFORM_EXPORT_FUNCTION(T) XALAN_PLATFORM_EXPORT T

--- a/src/xalanc/PlatformSupport/DirectoryEnumerator.hpp
+++ b/src/xalanc/PlatformSupport/DirectoryEnumerator.hpp
@@ -26,7 +26,7 @@
 
 
 #include <cstring>
-#if defined(_MSC_VER)
+#if defined(XALAN_WINDOWS)
 #include <io.h>
 #else
 #include <dirent.h>
@@ -59,7 +59,7 @@ using xercesc::MemoryManager;
 
 
 
-#if defined(_MSC_VER)
+#if defined(XALAN_WINDOWS)
 
 struct FindFileStruct : public _wfinddata_t
 {
@@ -240,7 +240,7 @@ EnumerateDirectory(
             bool                        fIncludeSelfAndParent = false)
 #endif
 {
-#if defined(_MSC_VER)
+#if defined(XALAN_WINDOWS)
     FindFileStruct      theFindData;
     
     #ifdef _WIN64
@@ -249,13 +249,17 @@ EnumerateDirectory(
         typedef long    theHandleType;
     #endif
 
+#if defined(_MSC_VER)
 #pragma warning(push)
 #pragma warning(disable: 4244)
+#endif
     theHandleType   theSearchHandle =
         _wfindfirst(
             reinterpret_cast<wchar_t*>(const_cast<XalanDOMChar*>(theConversionFunction(theFullSearchSpec))),
             &theFindData);
+#if defined(_MSC_VER)
 #pragma warning(pop)
+#endif
 
     if (theSearchHandle != -1)
     {

--- a/src/xalanc/PlatformSupport/DoubleSupport.hpp
+++ b/src/xalanc/PlatformSupport/DoubleSupport.hpp
@@ -25,7 +25,7 @@
 
 
 
-#if defined(_MSC_VER)
+#if defined(XALAN_WINDOWS)
 #include <float.h>
 #endif
 #include <cmath>

--- a/src/xalanc/PlatformSupport/XalanFileOutputStream.hpp
+++ b/src/xalanc/PlatformSupport/XalanFileOutputStream.hpp
@@ -40,8 +40,9 @@
 
 namespace XALAN_CPP_NAMESPACE {
 
-
+#if !defined(XALAN_WINDOWS)
 using std::FILE;
+#endif
 
 class XALAN_PLATFORMSUPPORT_EXPORT XalanFileOutputStream : public XalanOutputStream
 {

--- a/src/xalanc/XPathCAPI/XPathCAPI.h
+++ b/src/xalanc/XPathCAPI/XPathCAPI.h
@@ -20,7 +20,7 @@
 
 
 
-#if defined(_MSC_VER)
+#if defined(XALAN_WINDOWS)
 
 #if defined(XALAN_BUILD_DLL)
 

--- a/src/xalanc/XalanExe/XalanExe.cpp
+++ b/src/xalanc/XalanExe/XalanExe.cpp
@@ -44,7 +44,7 @@
 
 
 
-#if defined(_MSC_VER)
+#if defined(XALAN_WINDOWS)
 #define XALAN_USE_WINDOWS_TIMING
 #endif
 


### PR DESCRIPTION
Changes:
  * Check XALAN_WINDOWS instead of _MSC_VER for Win32 platform.
  * Check _MSC_VER for MSVC specific pragma directives.
  * Check Win32 platform for std::FILE type.