### PR TITLE
Fix build without macro XALAN_DEBUG

### DIFF
--- a/src/xalanc/XPath/MutableNodeRefList.cpp
+++ b/src/xalanc/XPath/MutableNodeRefList.cpp
@@ -704,7 +704,9 @@ MutableNodeRefList::clearNulls()
         m_order = eUnknownOrder;
     }
 
+#if defined(XALAN_DEBUG)
     assert(checkForDuplicates(getMemoryManager()) == false);
+#endif
 }
 
 

--- a/src/xalanc/XSLT/FunctionDocument.cpp
+++ b/src/xalanc/XSLT/FunctionDocument.cpp
@@ -573,7 +573,9 @@ FunctionDocument::doExecute(
         }
     }
 
+#if defined(XALAN_DEBUG)
     assert(mnl->checkForDuplicates(executionContext.getMemoryManager()) == false);
+#endif
 
     mnl->setDocumentOrder();
 


### PR DESCRIPTION
Fix build errors:
```
In file included from /usr/include/c++/9/cassert:44,
                 from /home/user1/dev/xalan-c/src/src/xalanc/Include/XalanList.hpp:31,
                 from /home/user1/dev/xalan-c/src/src/xalanc/Include/XalanMap.hpp:35,
                 from /home/user1/dev/xalan-c/src/src/xalanc/Include/STLHelper.hpp:33,
                 from /home/user1/dev/xalan-c/src/src/xalanc/XalanDOM/XalanDOMString.hpp:31,
                 from /home/user1/dev/xalan-c/src/src/xalanc/XPath/XPathExecutionContext.hpp:36,
                 from /home/user1/dev/xalan-c/src/src/xalanc/XPath/MutableNodeRefList.cpp:36:
/home/user1/dev/xalan-c/src/src/xalanc/XPath/MutableNodeRefList.cpp: In member function ‘void xalanc_1_12::MutableNodeRefList::clearNulls()’:
/home/user1/dev/xalan-c/src/src/xalanc/XPath/MutableNodeRefList.cpp:707:12: error: ‘checkForDuplicates’ was not declared in this scope
  707 |     assert(checkForDuplicates(getMemoryManager()) == false);
      |            ^~~~~~~~~~~~~~~~~~
```
and
```
In file included from /usr/include/c++/9/cassert:44,
                 from /home/user1/dev/xalan-c/src/src/xalanc/XPath/XObjectFactory.hpp:29,
                 from /home/user1/dev/xalan-c/src/src/xalanc/XSLT/FunctionDocument.cpp:42:
/home/user1/dev/xalan-c/src/src/xalanc/XSLT/FunctionDocument.cpp: In member function ‘xalanc_1_12::XObjectPtr xalanc_1_12::FunctionDocument::doExecute(xalanc_1_12::XPathExecutionContext&, xalanc_1_12::XalanNode*, const xalanc_1_12::XObjectPtr&, xalanc_1_12::XalanDOMString*, int, const xercesc_3_2::Locator*, bool) const’:
/home/user1/dev/xalan-c/src/src/xalanc/XSLT/FunctionDocument.cpp:576:17: error: ‘class xalanc_1_12::MutableNodeRefList’ has no member named ‘checkForDuplicates’
  576 |     assert(mnl->checkForDuplicates(executionContext.getMemoryManager()) == false);
      |                 ^~~~~~~~~~~~~~~~~~
```