### PR TITLE
Fix assertion for XML without documentElement, but with elements

### DIFF
--- a/src/xalanc/XPath/XPath.cpp
+++ b/src/xalanc/XPath/XPath.cpp
@@ -3537,6 +3537,12 @@ XPath::findRoot(
             }
             else
             {
+                if (DOMServices::getParentOfNode(*docContext) == 0 &&
+                    nodeType == XalanNode::ELEMENT_NODE)
+                {
+                    // docContext is root node
+                    break;
+                }
                 docContext =
                     DOMServices::getParentOfNode(*docContext);
                 assert(docContext != 0);


### PR DESCRIPTION
Fix assertion for XML document with elements, but without documentElement.