### PR TITLE
Fix compilation with -Werror=odr

### DIFF
--- a/src/xalanc/PlatformSupport/AttributeListImpl.cpp
+++ b/src/xalanc/PlatformSupport/AttributeListImpl.cpp
@@ -242,6 +242,9 @@ AttributeListImpl:: getValue(const char* const /*name*/) const
 
 
 
+namespace
+{
+
 struct NameCompareFunctor
 {
     NameCompareFunctor(const XMLCh*     theName) :
@@ -259,6 +262,8 @@ private:
 
     const XMLCh* const  m_name;
 };
+
+}	// --- namespace
 
 
 

--- a/src/xalanc/PlatformSupport/AttributesImpl.cpp
+++ b/src/xalanc/PlatformSupport/AttributesImpl.cpp
@@ -253,6 +253,9 @@ AttributesImpl::getValue(const XalanSize_t  index) const
 
 
 
+namespace
+{
+
 struct NameCompareFunctor
 {
     NameCompareFunctor(const XMLCh*     theQName) :
@@ -270,6 +273,8 @@ private:
 
     const XMLCh* const  m_qname;
 };
+
+}	// --- namespace
 
 
 


### PR DESCRIPTION
error: type ‘struct NameCompareFunctor’ violates the C++ One Definition Rule [-Werror=odr]

See also: https://bugs.gentoo.org/856097