### PR TITLE
Clear cached number value when XString is set()

### DIFF
--- a/src/xalanc/XPath/XString.hpp
+++ b/src/xalanc/XPath/XString.hpp
@@ -89,6 +89,7 @@ public:
     set(const XalanDOMString&   theString)
     {
         m_value = theString;
+        ClearCachedNumber();
     }
 
     // These methods are inherited from XObject ...

--- a/src/xalanc/XPath/XStringBase.cpp
+++ b/src/xalanc/XPath/XStringBase.cpp
@@ -154,6 +154,11 @@ XStringBase::str() const
                 theBuffer);
 }
 
+void
+XStringBase::ClearCachedNumber()
+{
+    m_cachedNumberValue = 0.0;
+}
 
 
 }

--- a/src/xalanc/XPath/XStringBase.hpp
+++ b/src/xalanc/XPath/XStringBase.hpp
@@ -128,6 +128,9 @@ public:
     virtual void
     ProcessXObjectTypeCallback(XObjectTypeCallback&     theCallbackObject) const;
 
+    virtual void
+    ClearCachedNumber();
+
 private:
 
     friend class XObjectResultTreeFragProxyText;


### PR DESCRIPTION
Fixed an issue when old cache number value is used when XString is set()